### PR TITLE
Adjust maven packaging configuration

### DIFF
--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -27,16 +27,6 @@
       <artifactId>inrupt-rdf-wrapping-rdf4j</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.inrupt</groupId>
-      <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.inrupt</groupId>
-      <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>
-      <version>${project.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/test/commons/pom.xml
+++ b/test/commons/pom.xml
@@ -46,6 +46,13 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>
   <name>Inrupt RDF Wrapping Tests - Jena</name>
+  <packaging>pom</packaging>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -9,6 +9,7 @@
 
   <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>
   <name>Inrupt RDF Wrapping Tests - RDF4J</name>
+  <packaging>pom</packaging>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
This adjusts the maven packaging so that modules that do not contain any code in `./src/main` are given the `pom` packaging. Also, there is no need to include the test modules in the report module, since we're not checking code coverage on test modules.

Finally, this turns off the PMD checks on the test module, since that's not useful information.