### PR TITLE
Undo Maven packaging configuration

### DIFF
--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -27,6 +27,16 @@
       <artifactId>inrupt-rdf-wrapping-rdf4j</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.inrupt</groupId>
+      <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.inrupt</groupId>
+      <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -9,7 +9,6 @@
 
   <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>
   <name>Inrupt RDF Wrapping Tests - Jena</name>
-  <packaging>pom</packaging>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -9,7 +9,6 @@
 
   <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>
   <name>Inrupt RDF Wrapping Tests - RDF4J</name>
-  <packaging>pom</packaging>
 
   <properties>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
#19 removed two modules from report and made them packaged as POMs.

The affected modules are used to run Commons RDF tests with a given implementation library (one for Jena, one for RDF4J).

Those changes result in Commons tests not running in the build and their coverage not collected in the report.

I previously had the same idea: Test modules don't produce JARs, so I should package them accordingly. But I noticed tests are thus not run or reported.

@acoburn, I saw you had the same structure in the JCL and had to change it in inrupt/solid-client-java#279 to make integration tests run in CI.

We can see the [reduction in coverage](https://sonarqube.dev.inrupt.com/dashboard?id=rdf-wrapping) due to the previous change reverted in this PR:
![image](https://user-images.githubusercontent.com/240741/218465587-c36fd28c-aa50-4f4a-af08-0e59819d87c5.png)