### PR TITLE
Javadoc fixes, improve CI for javadoc validation

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -23,5 +23,5 @@ jobs:
           cache: 'maven'
 
       - name: Build the code with Maven
-        run: mvn -B -ntp verify
+        run: mvn -B -ntp verify javadoc:javadoc
 

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNode.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNode.java
@@ -35,7 +35,7 @@ public class WrapperBlankNode extends WrapperBlankNodeOrIRI implements BlankNode
     /**
      * Create a new subject node with a backing {@link Graph} object.
      *
-     * @param original The subject node, must be a non-null {@link IRI}
+     * @param original The subject node, must be a non-null {@link BlankNode}
      * @param graph The wrapped graph, may not be {@code null}
      */
     protected WrapperBlankNode(final RDFTerm original, final Graph graph) {

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
@@ -81,7 +81,7 @@ import org.apache.jena.shared.PropertyNotFoundException;
  */
 public abstract class WrapperResource extends ResourceImpl {
     /**
-     * Create a new subject resource with a backing {@link Graph} structure.
+     * Create a new subject resource with a backing {@link EnhGraph} structure.
      *
      * @param node the subject node
      * @param model the rdf model


### PR DESCRIPTION
This fixes a few javadoc errors introduced in the last commit and adjusts the CI workflow to catch these errors early in the future.