### PR TITLE
JCL-321: Add rdf component to groupId

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
@@ -23,13 +23,13 @@
     </dependency>
 
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-base</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.inrupt</groupId>
+  <groupId>com.inrupt.rdf</groupId>
   <artifactId>inrupt-rdf-wrapping</artifactId>
   <version>0.3.1-SNAPSHOT</version>
   <name>Inrupt RDF Wrapping Java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <commons.rdf.version>0.5.0</commons.rdf.version>
     <rdf4j.version>4.2.3</rdf4j.version>
     <jena.version>4.7.0</jena.version>
-    <inrupt.commons.rdf4j.version>0.5.0</inrupt.commons.rdf4j.version>
+    <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
 
     <!-- plugins -->
     <buildhelper.plugin.version>3.3.0</buildhelper.plugin.version>
@@ -103,7 +103,7 @@
         <version>${commons.rdf.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.inrupt</groupId>
+        <groupId>com.inrupt.rdf</groupId>
         <artifactId>inrupt-commons-rdf4j</artifactId>
         <version>${inrupt.commons.rdf4j.version}</version>
       </dependency>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
@@ -18,7 +18,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -38,7 +38,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-base</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -23,7 +23,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-commons-rdf4j</artifactId>
     </dependency>
     <dependency>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
@@ -13,27 +13,27 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-jena</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-rdf4j</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>

--- a/test/commons/pom.xml
+++ b/test/commons/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
@@ -17,7 +17,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -27,7 +27,7 @@
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-base</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
@@ -17,13 +17,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-commons</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -30,7 +30,7 @@
     </dependency>
 
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-commons-rdf4j</artifactId>
       <scope>test</scope>
     </dependency>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>com.inrupt</groupId>
+    <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
     <version>0.3.1-SNAPSHOT</version>
   </parent>
@@ -17,13 +17,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-commons</artifactId>
       <version>${project.version}</version>
     </dependency>
 
     <dependency>
-      <groupId>com.inrupt</groupId>
+      <groupId>com.inrupt.rdf</groupId>
       <artifactId>inrupt-rdf-wrapping-test-commons</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>


### PR DESCRIPTION
This changes the groupId from `com.inrupt` to `com.inrupt.rdf` so that no all artifacts are in a single namespace.