### PR TITLE
Release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ To use the library in your own project you can add the dependency to your build.
     <inrupt.rdf.wrapping.version>x.x.x</inrupt.rdf.wrapping.version>
 </properties>
 <dependency>
-      <groupId>com.inrupt</groupId>
-      <artifactId>inrupt-rdf-wrapping-commons</artifactId>
-      <version>${inrupt.rdf.wrapping.version}</version>
-    </dependency>
+    <groupId>com.inrupt.rdf</groupId>
+    <artifactId>inrupt-rdf-wrapping-commons</artifactId>
+    <version>${inrupt.rdf.wrapping.version}</version>
+</dependency>
 ```
 
 ## Using this repository locally

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-commons</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-commons</artifactId>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-jena</artifactId>

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-jena</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.inrupt.rdf</groupId>
   <artifactId>inrupt-rdf-wrapping</artifactId>
-  <version>0.4.0</version>
+  <version>0.4.1-SNAPSHOT</version>
   <name>Inrupt RDF Wrapping Java</name>
   <url>https://inrupt.github.io/rdf-wrapping-java/</url>
   <description>Inrupt RDF Wrapping Java libraries</description>
@@ -674,7 +674,7 @@
     <connection>scm:git:git://github.com/inrupt/rdf-wrapping.git</connection>
     <developerConnection>scm:git:git@github.com:inrupt/rdf-wrapping.git</developerConnection>
     <url>https://github.com/inrupt/rdf-wrapping</url>
-    <tag>inrupt-rdf-wrapping-0.4.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.inrupt.rdf</groupId>
   <artifactId>inrupt-rdf-wrapping</artifactId>
-  <version>0.3.1-SNAPSHOT</version>
+  <version>0.4.0</version>
   <name>Inrupt RDF Wrapping Java</name>
   <url>https://inrupt.github.io/rdf-wrapping-java/</url>
   <description>Inrupt RDF Wrapping Java libraries</description>
@@ -674,7 +674,7 @@
     <connection>scm:git:git://github.com/inrupt/rdf-wrapping.git</connection>
     <developerConnection>scm:git:git@github.com:inrupt/rdf-wrapping.git</developerConnection>
     <url>https://github.com/inrupt/rdf-wrapping</url>
-    <tag>HEAD</tag>
+    <tag>inrupt-rdf-wrapping-0.4.0</tag>
   </scm>
 
   <licenses>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-rdf4j</artifactId>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-rdf4j</artifactId>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-report</artifactId>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-report</artifactId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-base</artifactId>

--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-base</artifactId>

--- a/test/commons/pom.xml
+++ b/test/commons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-commons</artifactId>

--- a/test/commons/pom.xml
+++ b/test/commons/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-commons</artifactId>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-jena</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test</artifactId>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.4.0</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.inrupt.rdf</groupId>
     <artifactId>inrupt-rdf-wrapping-test</artifactId>
-    <version>0.4.0</version>
+    <version>0.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>inrupt-rdf-wrapping-test-rdf4j</artifactId>


### PR DESCRIPTION
This brings the 0.4.0 release commits into the main line of development.

Note: This also adjusts the README to include the correct `groupId` value.