### PR TITLE
JCL-329: Simplify security reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: false
-contact_links:
-  - name: Security Vulnerability Reporting
-    url: https://inrupt.com/security/
-    about: Please report vulnerabilities following the instructions provided at the link.


### PR DESCRIPTION
This simplifies the configuration for security reporting so that we don't have two separate paths for reporting vulnerabilities.