### PR TITLE
Use standard java methods for stream handling

### DIFF
--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ObjectSet.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ObjectSet.java
@@ -24,10 +24,10 @@ import java.util.*;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-import org.apache.jena.ext.com.google.common.collect.Iterators;
-import org.apache.jena.ext.com.google.common.collect.Streams;
 import org.apache.jena.rdf.model.*;
+import org.apache.jena.util.iterator.ExtendedIterator;
 
 /**
  * This class implements the {@link Set} interface as a dynamic, mutable view over an RDF predicate-object list
@@ -113,7 +113,13 @@ public class ObjectSet<T> extends AbstractSet<T> {
 
     @Override
     public int size() {
-        return Iterators.size(statements());
+        int total = 0;
+        final ExtendedIterator iter = statements();
+        while (iter.hasNext()) {
+            total += 1;
+            iter.next();
+        }
+        return total;
     }
 
     @Override
@@ -235,7 +241,8 @@ public class ObjectSet<T> extends AbstractSet<T> {
     }
 
     private Stream<RDFNode> objects() {
-        return Streams.stream(statements()).map(Statement::getObject);
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(statements(), Spliterator.NONNULL), false)
+            .map(Statement::getObject);
     }
 
     private Stream<T> values() {

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
@@ -27,10 +27,12 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.apache.jena.enhanced.EnhGraph;
-import org.apache.jena.ext.com.google.common.collect.Streams;
 import org.apache.jena.graph.Node;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Statement;
@@ -246,7 +248,8 @@ public abstract class WrapperResource extends ResourceImpl {
         Objects.requireNonNull(p);
         Objects.requireNonNull(m);
 
-        return Streams.stream(objectIterator(p, m));
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(objectIterator(p, m), Spliterator.NONNULL),
+                false);
     }
 
     /**


### PR DESCRIPTION
Up through Jena 4.8, there is a shaded copy of Guava used internally. Those internal classes are public but not recommended to be used externally, but they are being used by the wrapper library.

In Jena 4.9, these classes are removed, and so this PR updates how iterators are processed so that we can continue to support the newer Jena versions