### PR TITLE
Update and enforce license header

### DIFF
--- a/build-tools/license/HEADER.txt
+++ b/build-tools/license/HEADER.txt
@@ -1,4 +1,4 @@
-Copyright 2023 Inrupt Inc.
+Copyright Inrupt Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/RDFFactory.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/RDFFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/TermMapping.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/TermMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/TermMappings.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/TermMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ValueMapping.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ValueMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ValueMappings.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ValueMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNode.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperDataset.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperDataset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperGraph.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperIRI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/package-info.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/test/java/com/inrupt/rdf/wrapping/commons/ExceptionUtils.java
+++ b/commons/src/test/java/com/inrupt/rdf/wrapping/commons/ExceptionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/test/java/com/inrupt/rdf/wrapping/commons/RdfFactoryTest.java
+++ b/commons/src/test/java/com/inrupt/rdf/wrapping/commons/RdfFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeTest.java
+++ b/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperDatasetTest.java
+++ b/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperDatasetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperGraphTest.java
+++ b/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperIRITest.java
+++ b/commons/src/test/java/com/inrupt/rdf/wrapping/commons/WrapperIRITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/NodeMapping.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/NodeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/NodeMappings.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/NodeMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ObjectSet.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ObjectSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/UriOrBlankFactory.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/UriOrBlankFactory.java
@@ -1,9 +1,22 @@
 /*
- * Proprietary and Confidential
+ * Copyright Inrupt Inc.
  *
- * Copyright Inrupt Inc. 2023 - all rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
  *
- * Do not use without explicit permission from Inrupt Inc.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package com.inrupt.rdf.wrapping.jena;
 

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ValueMapping.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ValueMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ValueMappings.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/ValueMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/package-info.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/rdf/wrapping/jena/NodeMappingsTest.java
+++ b/jena/src/test/java/com/inrupt/rdf/wrapping/jena/NodeMappingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/rdf/wrapping/jena/ObjectSetTest.java
+++ b/jena/src/test/java/com/inrupt/rdf/wrapping/jena/ObjectSetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/rdf/wrapping/jena/UriOrBlankFactoryTest.java
+++ b/jena/src/test/java/com/inrupt/rdf/wrapping/jena/UriOrBlankFactoryTest.java
@@ -1,9 +1,22 @@
 /*
- * Proprietary and Confidential
+ * Copyright Inrupt Inc.
  *
- * Copyright Inrupt Inc. 2023 - all rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
  *
- * Do not use without explicit permission from Inrupt Inc.
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 package com.inrupt.rdf.wrapping.jena;
 

--- a/jena/src/test/java/com/inrupt/rdf/wrapping/jena/ValueMappingsTest.java
+++ b/jena/src/test/java/com/inrupt/rdf/wrapping/jena/ValueMappingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/jena/src/test/java/com/inrupt/rdf/wrapping/jena/WrapperResourceTest.java
+++ b/jena/src/test/java/com/inrupt/rdf/wrapping/jena/WrapperResourceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,11 @@
           <version>${jar.plugin.version}</version>
         </plugin>
         <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license.plugin.version}</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${javadoc.plugin.version}</version>
@@ -434,6 +439,31 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <header>./build-tools/license/HEADER.txt</header>
+          <mapping>
+            <java>SLASHSTAR_STYLE</java>
+          </mapping>
+          <excludes>
+            <exclude>**/src/main/resources/**</exclude>
+            <exclude>**/src/test/resources/**</exclude>
+          </excludes>
+          <includes>
+            <include>**/src/main/java/**</include>
+            <include>**/src/test/java/**</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/ObjectSet.java
+++ b/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/ObjectSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/RdfValueMapping.java
+++ b/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/RdfValueMapping.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.inrupt.rdf.wrapping.rdf4j;
 
 

--- a/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/RdfValueMappings.java
+++ b/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/RdfValueMappings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/ValueMapping.java
+++ b/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/ValueMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/package-info.java
+++ b/rdf4j/src/main/java/com/inrupt/rdf/wrapping/rdf4j/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/rdf4j/src/test/java/com/inrupt/rdf/wrapping/rdf4j/ObjectSetTest.java
+++ b/rdf4j/src/test/java/com/inrupt/rdf/wrapping/rdf4j/ObjectSetTest.java
@@ -1,3 +1,23 @@
+/*
+ * Copyright Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
 package com.inrupt.rdf.wrapping.rdf4j;
 
 import com.inrupt.rdf.wrapping.test.base.ObjectSetBase;

--- a/rdf4j/src/test/java/com/inrupt/rdf/wrapping/rdf4j/RdfValueMappingsTest.java
+++ b/rdf4j/src/test/java/com/inrupt/rdf/wrapping/rdf4j/RdfValueMappingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/base/src/main/java/com/inrupt/rdf/wrapping/test/base/HasSameMethods.java
+++ b/test/base/src/main/java/com/inrupt/rdf/wrapping/test/base/HasSameMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/base/src/main/java/com/inrupt/rdf/wrapping/test/base/ObjectSetBase.java
+++ b/test/base/src/main/java/com/inrupt/rdf/wrapping/test/base/ObjectSetBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/CommonsObjectSetBase.java
+++ b/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/CommonsObjectSetBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/RdfFactoryBase.java
+++ b/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/RdfFactoryBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/TermMappingsBase.java
+++ b/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/TermMappingsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/ValueMappingsBase.java
+++ b/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/ValueMappingsBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/WrapperBlankNodeOrIRIBase.java
+++ b/test/commons/src/main/java/com/inrupt/rdf/wrapping/test/commons/WrapperBlankNodeOrIRIBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/jena/src/test/java/com/inrupt/rdf/wrapping/test/jena/Test.java
+++ b/test/jena/src/test/java/com/inrupt/rdf/wrapping/test/jena/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in

--- a/test/rdf4j/src/test/java/com/inrupt/rdf/wrapping/test/rdf4j/Test.java
+++ b/test/rdf4j/src/test/java/com/inrupt/rdf/wrapping/test/rdf4j/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Inrupt Inc.
+ * Copyright Inrupt Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
This updates the license header to use the standard Inrupt style. It also applies the license plugin to the maven configuration so that the license header is enforced.