### PR TITLE
JCL-427: Ensure that inherited project URLs are correct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" child.project.url.inherit.append.path="false">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.inrupt.rdf</groupId>
@@ -641,10 +641,10 @@
     </developer>
   </developers>
 
-  <scm>
-    <connection>scm:git:git://github.com/inrupt/rdf-wrapping.git</connection>
-    <developerConnection>scm:git:git@github.com:inrupt/rdf-wrapping.git</developerConnection>
-    <url>https://github.com/inrupt/rdf-wrapping</url>
+  <scm child.scm.url.inherit.append.path="false" child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false">
+    <connection>scm:git:git://github.com/inrupt/rdf-wrapping-java.git</connection>
+    <developerConnection>scm:git:git@github.com:inrupt/rdf-wrapping-java.git</developerConnection>
+    <url>https://github.com/inrupt/rdf-wrapping-java</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
See https://github.com/inrupt/solid-client-java/pull/606 for additional context.

This adjusts the maven configuration so that URLs published with the various submodules are correct.