### PR TITLE
Update dependency-check to use an NVD API key

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -25,10 +25,31 @@ jobs:
       - name: Build the code with Maven
         run: mvn -B -ntp verify javadoc:javadoc
 
+  dependencies:
+    name: Dependency Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 17 ]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+
+      - name: Build the code with Maven
+        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+
   check:
     if: always()
     needs:
       - build
+      - dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,7 @@
           </execution>
         </executions>
         <configuration>
+          <cveValidForHours>24</cveValidForHours>
           <failBuildOnCVSS>7</failBuildOnCVSS>
           <formats>
             <format>HTML</format>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <javadoc.plugin.version>3.6.3</javadoc.plugin.version>
     <license.plugin.version>4.3</license.plugin.version>
     <nexus.plugin.version>1.6.13</nexus.plugin.version>
-    <owasp.plugin.version>8.4.3</owasp.plugin.version>
+    <owasp.plugin.version>9.0.5</owasp.plugin.version>
     <projectinfo.plugin.version>3.4.1</projectinfo.plugin.version>
     <pmd.plugin.version>3.21.2</pmd.plugin.version>
     <release.plugin.version>3.0.1</release.plugin.version>
@@ -54,6 +54,10 @@
     <slf4j.version>2.0.9</slf4j.version>
     <hamcrest.version>2.2</hamcrest.version>
     <mockito.version>5.8.0</mockito.version>
+
+    <!-- disable by default (enabled by profile in CI) -->
+    <dependency-check.skip>true</dependency-check.skip>
+    <nvd.api.key/>
 
     <!-- sonar -->
     <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/reports/target/site/jacoco-merged/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
@@ -539,6 +543,7 @@
           <suppressionFile>
               ./build-tools/owasp/suppressions.xml
           </suppressionFile>
+          <nvdApiKey>${nvd.api.key}</nvdApiKey>
         </configuration>
       </plugin>
     </plugins>
@@ -614,6 +619,17 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>dependencies</id>
+      <properties>
+        <skipTests>true</skipTests>
+        <pmd.skip>true</pmd.skip>
+        <cpd.skip>true</cpd.skip>
+        <dependency-check.skip>false</dependency-check.skip>
+        <jacoco.skip>true</jacoco.skip>
+        <checkstyle.skip>true</checkstyle.skip>
+      </properties>
     </profile>
     <profile>
       <id>website</id>


### PR DESCRIPTION
This upgrades the `dependency-check` plugin to version 9.x, adding support for NVD API v2 and using an API key. This also adds a specific CI job for performing the dependency check

Supersedes #132 