### PR TITLE
Use a cache for the NVD API data

### DIFF
--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -42,16 +42,20 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
-      - name: Generate Cache Name
-        shell: bash
-        run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
+      - name: Build the code with Maven
+        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
 
-      - name: Restore NVD data cache
-        uses: actions/cache@v3
-        with:
-          key: nvd-data-${{ env.CACHE_NAME }}
-          restore-keys: nvd-data-
-          path: ./data/cache
+      # Uncomment when the cache has become available
+      #- name: Generate Cache Name
+        #shell: bash
+        #run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
+
+      #- name: Restore NVD data cache
+        #uses: actions/cache@v3
+        #with:
+          #key: nvd-data-${{ env.CACHE_NAME }}
+          #restore-keys: nvd-data-
+          #path: ./data/cache
 
       - name: Verify dependencies
         run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -42,20 +42,16 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
-      - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+      - name: Generate Cache Name
+        shell: bash
+        run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
 
-      # Uncomment when the cache has become available
-      #- name: Generate Cache Name
-        #shell: bash
-        #run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
-
-      #- name: Restore NVD data cache
-        #uses: actions/cache@v3
-        #with:
-          #key: nvd-data-${{ env.CACHE_NAME }}
-          #restore-keys: nvd-data-
-          #path: ./data/cache
+      - name: Restore NVD data cache
+        uses: actions/cache@v3
+        with:
+          key: nvd-data-${{ env.CACHE_NAME }}
+          restore-keys: nvd-data-
+          path: ./data/cache
 
       - name: Verify dependencies
         run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -42,8 +42,19 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
-      - name: Build the code with Maven
-        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.key=${{ secrets.NVD_API_KEY }}
+      - name: Generate Cache Name
+        shell: bash
+        run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
+
+      - name: Restore NVD data cache
+        uses: actions/cache@v3
+        with:
+          key: nvd-data-${{ env.CACHE_NAME }}
+          restore-keys: nvd-data-
+          path: ./data/cache
+
+      - name: Verify dependencies
+        run: mvn -B -ntp verify -Pdependencies -Dnvd.api.datafeed="file:${GITHUB_WORKSPACE}/data/cache/nvdcve-{0}.json.gz"
 
   check:
     if: always()

--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -3,6 +3,9 @@ name: NVD Data Workflow CD
 on:
   schedule:
     - cron: '0 4 * * 1,2,3,4,5'
+  push:
+    branches:
+      - nvd-api-cache
 
 jobs:
   build:

--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -3,9 +3,6 @@ name: NVD Data Workflow CD
 on:
   schedule:
     - cron: '0 4 * * 1,2,3,4,5'
-  push:
-    branches:
-      - nvd-api-cache
 
 jobs:
   build:

--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -1,0 +1,54 @@
+name: NVD Data Workflow CD
+
+on:
+  schedule:
+    - cron: '0 4 * * 1,2,3,4,5'
+
+jobs:
+  build:
+    name: Build and collect data
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+
+    steps:
+    - name: Checkout OVP repository
+      uses: actions/checkout@v4
+      with:
+        repository: jeremylong/Open-Vulnerability-Project
+        path: ovp
+        ref: v5.1.1
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: 17
+        cache: 'gradle'
+
+    - name: Build the OVP code with Gradle
+      working-directory: ./ovp
+      run: ./gradlew build -x test
+
+    - uses: actions/checkout@v4
+      with:
+        path: data
+
+    - name: Generate Cache Name
+      shell: bash
+      run: echo "CACHE_NAME=$(date '+%y.%j')" >> $GITHUB_ENV
+
+    - name: Rename artifact
+      run: find ./ovp/vulnz/build/libs -type f -regex './ovp/vulnz/build/libs/vulnz-[0-9].[0-9].[0-9].jar' -exec mv {} ./data/vulnz.jar ';'
+
+    - name: Generate data
+      working-directory: ./data
+      run: ./vulnz.jar cve --cache --directory ./cache
+      env:
+        NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+
+    - name: Cache NVD data
+      uses: actions/cache@v3
+      with:
+        key: nvd-data-${{ env.CACHE_NAME }}
+        path: ./data/cache
+        enableCrossOsArchive: false


### PR DESCRIPTION
This makes use of a repository cache when performing the `dependency-check` validation. In addition, a scheduled job is run daily to refresh this cache.

GitHub will automatically expire old caches