### PR TITLE
Add workflow dispatch trigger

### DIFF
--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -3,6 +3,7 @@ name: NVD Data Workflow CD
 on:
   schedule:
     - cron: '0 4 * * 1,2,3,4,5'
+  workflow_dispatch: { }
 
 jobs:
   build:

--- a/.github/workflows/nvd-cache.yml
+++ b/.github/workflows/nvd-cache.yml
@@ -52,4 +52,3 @@ jobs:
       with:
         key: nvd-data-${{ env.CACHE_NAME }}
         path: ./data/cache
-        enableCrossOsArchive: false


### PR DESCRIPTION
This makes it possible to trigger a NVD cache generation via the GH web interface.