### PR TITLE
Handle iterables correctly

### DIFF
--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
@@ -274,7 +274,7 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
         v.forEach(Objects::requireNonNull);
 
         remove(p);
-        v.forEach(value -> add(p, v, m));
+        v.forEach(value -> add(p, value, m));
     }
 
     /**

--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
@@ -289,7 +289,7 @@ public abstract class WrapperResource extends ResourceImpl {
         v.forEach(Objects::requireNonNull);
 
         removeAll(p);
-        v.forEach(value -> add(p, v, m));
+        v.forEach(value -> add(p, value, m));
     }
 
     /**

--- a/jena/src/test/java/com/inrupt/rdf/wrapping/jena/WrapperResourceTest.java
+++ b/jena/src/test/java/com/inrupt/rdf/wrapping/jena/WrapperResourceTest.java
@@ -39,6 +39,7 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.jena.enhanced.EnhGraph;
 import org.apache.jena.enhanced.Implementation;
 import org.apache.jena.graph.Node;
+import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.ResourceFactory;
 import org.apache.jena.rdf.model.Statement;
@@ -299,6 +300,22 @@ class WrapperResourceTest extends HasSameMethods {
                 contains(hasProperty("literal", hasProperty("lexicalForm", is(O2)))));
     }
 
+    @DisplayName("overwrite (*) removes and adds each item instead of collection")
+    @Test
+    void overwriteManyPassesItemNotIterable() {
+        s.addProperty(P, O1);
+
+        final List<String> value = new ArrayList<>();
+        value.add(O2);
+        value.add(O2); // same is OK because mapping in this case is dynamic to fresh blank nodes
+
+        s.overwriteDynamic(value);
+
+        assertThat(
+                (Iterable<Statement>) () -> s.listProperties(P),
+                iterableWithSize(2));
+    }
+
     @DisplayName("overwriteNullable (1) removes when value is null")
     @Test
     void overwriteOneNullableRemovesIfNull() {
@@ -461,6 +478,10 @@ class WrapperResourceTest extends HasSameMethods {
 
         public void overwrite(final Iterable<String> value) {
             overwrite(P, value, NM);
+        }
+
+        public void overwriteDynamic(final Iterable<String> value) {
+            overwrite(P, value, (String v, Model g) -> ResourceFactory.createResource());
         }
 
         public void overwriteNullable(final String value) {


### PR DESCRIPTION
[Expected CI failure on repro](https://github.com/inrupt/rdf-wrapping-java/actions/runs/7584474745/job/20658209253?pr=146#step:4:783)

---

### Summary
There is a problem with the destructive plural setter helper `WrapperResource#overwrite(Iterable)` where (after removing previous statements with a given predicate) instead of adding a statement for each item, it adds the whole collection of items.

This results in a power set of the items being added.
This is not a practical problem in most cases, since the superfluous statements are smushed by statement identity.
But when the node mapping function creates fresh blank nodes for each item then each statement of the power set is distinct and the problem manifests.

The actual problem is probably a copy & paste artefact resulting in passing the iterable paramater of the method instead of the individual parameter of the `forEach` lambda.

### Old (errorneous) code:
https://github.com/inrupt/rdf-wrapping-java/blob/025923ccb7467c96d8751b93466270f41fb92136/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java#L292

### New (fixed) code which is the substance of this proposed change:
https://github.com/inrupt/rdf-wrapping-java/blob/2639c8b2c2dda2db1cbf7fd2acde70806db70b24/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java#L292

### Proposed change log entry:

> Bugfix: Both the Jena and Commons RDF implementations now correctly overwrite `Iterable` properties instead of adding the items multiple times.

---

Thanks @edwardsph for the report and for spotting the problem during walkthrough.