### PR TITLE
JCL-456: Close streams

### DIFF
--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
@@ -136,7 +136,8 @@ public class ObjectSet<T> extends AbstractSet<T> {
     @Override
     public Iterator<T> iterator() {
         try (final Stream<T> stream = values()) {
-            return stream.collect(Collectors.toList()).stream().iterator();
+            return stream.collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList))
+                .iterator();
         }
     }
 

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
@@ -136,7 +136,7 @@ public class ObjectSet<T> extends AbstractSet<T> {
     @Override
     public Iterator<T> iterator() {
         try (final Stream<T> stream = values()) {
-            return stream.iterator();
+            return stream.collect(Collectors.toList()).stream().iterator();
         }
     }
 

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
@@ -133,6 +133,11 @@ public class ObjectSet<T> extends AbstractSet<T> {
         return graph.contains(subject, predicate, object);
     }
 
+    /**
+     * @implNote Prior to returning the iterator, this implementation consumes (buffers) an underlying
+     * {@link Graph#stream(BlankNodeOrIRI, IRI, RDFTerm) stream of statements} with the current {@link #subject} and
+     * {@link #predicate} as well as the {@link #valueMapping value mapping function} applied to each object.
+     */
     @Override
     public Iterator<T> iterator() {
         try (final Stream<T> stream = values()) {

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/ObjectSet.java
@@ -112,8 +112,10 @@ public class ObjectSet<T> extends AbstractSet<T> {
 
     @Override
     public int size() {
-        final long size = statements().count();
-        return size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
+        try (final Stream<? extends Triple> stream = statements()) {
+            final long size = stream.count();
+            return size > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
+        }
     }
 
     @Override
@@ -133,12 +135,16 @@ public class ObjectSet<T> extends AbstractSet<T> {
 
     @Override
     public Iterator<T> iterator() {
-        return values().iterator();
+        try (final Stream<T> stream = values()) {
+            return stream.iterator();
+        }
     }
 
     @Override
     public Object[] toArray() {
-        return values().toArray();
+        try (final Stream<T> stream = values()) {
+            return stream.toArray();
+        }
     }
 
     @Override
@@ -197,9 +203,11 @@ public class ObjectSet<T> extends AbstractSet<T> {
     public boolean retainAll(final Collection<?> c) {
         Objects.requireNonNull(c);
 
-        return values().collect(Collectors.toList()).stream()
+        try (final Stream<T> stream = values()) {
+            return stream.collect(Collectors.toList()).stream()
                 .map(value -> removeUnlessContains(c, value))
                 .reduce(false, EITHER);
+        }
     }
 
     // AbstractSet#removeAll relies on Iterator#remove, which is not supported here.

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.rdf.api.*;
@@ -191,7 +192,7 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
         Objects.requireNonNull(m);
 
         try (final Stream<T> stream = objectStream(p, m)) {
-            return stream.iterator();
+            return stream.collect(Collectors.toList()).stream().iterator();
         }
     }
 

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
@@ -103,7 +103,9 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
         Objects.requireNonNull(p);
         Objects.requireNonNull(m);
 
-        return objectStream(p, m).findAny().orElse(null);
+        try (final Stream<T> stream = objectStream(p, m)) {
+            return stream.findAny().orElse(null);
+        }
     }
 
     /**
@@ -188,7 +190,9 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
         Objects.requireNonNull(p);
         Objects.requireNonNull(m);
 
-        return objectStream(p, m).iterator();
+        try (final Stream<T> stream = objectStream(p, m)) {
+            return stream.iterator();
+        }
     }
 
     /**
@@ -204,7 +208,9 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
         Objects.requireNonNull(p);
         Objects.requireNonNull(m);
 
-        return objectStream(p, m).collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
+        try (final Stream<T> stream = objectStream(p, m)) {
+            return stream.collect(collectingAndThen(toSet(), Collections::unmodifiableSet));
+        }
     }
 
     /**

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
@@ -192,7 +192,8 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
         Objects.requireNonNull(m);
 
         try (final Stream<T> stream = objectStream(p, m)) {
-            return stream.collect(Collectors.toList()).stream().iterator();
+            return stream.collect(Collectors.collectingAndThen(Collectors.toList(), Collections::unmodifiableList))
+                .iterator();
         }
     }
 

--- a/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
+++ b/commons/src/main/java/com/inrupt/rdf/wrapping/commons/WrapperBlankNodeOrIRI.java
@@ -186,6 +186,10 @@ public abstract class WrapperBlankNodeOrIRI implements BlankNodeOrIRI {
      * @param <T> the type of values returned
      *
      * @return the converted objects of statements with this subject and the given predicate
+     *
+     * @implNote Prior to returning the iterator, this implementation consumes (buffers) an underlying
+     * {@link Graph#stream(BlankNodeOrIRI, IRI, RDFTerm) stream of statements} with the predicate {@code p} and the
+     * mapping function {@code m} applied to each object.
      */
     protected <T> Iterator<T> objectIterator(final IRI p, final ValueMapping<T> m) {
         Objects.requireNonNull(p);

--- a/jena/pom.xml
+++ b/jena/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
       </dependency>
+      <!-- patch CVE-2024-25710 commons-compress 1.26.0 -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.26.0</version>
+      </dependency>
 
       <!-- testing -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,6 @@
           </execution>
         </executions>
         <configuration>
-          <cveValidForHours>24</cveValidForHours>
           <failBuildOnCVSS>7</failBuildOnCVSS>
           <formats>
             <format>HTML</format>

--- a/rdf4j/pom.xml
+++ b/rdf4j/pom.xml
@@ -43,6 +43,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/test/commons/pom.xml
+++ b/test/commons/pom.xml
@@ -35,6 +35,10 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -34,6 +34,11 @@
       <artifactId>jena-commonsrdf</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -46,6 +46,11 @@
       <artifactId>rdf4j-repository-sail</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
This explicitly closes `Stream<>` constructs where appropriate. This is not relevant for Jena which always uses in-memory constructs for streams, but RDF4J uses AutoClosable resources in this context, so the streams need to be explicitly closed.

In addition, this updates the transitive dependency `commons-compress`