### PR TITLE
Adjust wrapper resource documentation

### DIFF
--- a/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
+++ b/jena/src/main/java/com/inrupt/rdf/wrapping/jena/WrapperResource.java
@@ -60,11 +60,12 @@ import org.apache.jena.shared.PropertyNotFoundException;
  * <p>This table details the behavior of plural getter helper methods in terms of reflecting changes to the underlying
  * graph after calling them:
  * <pre>
- * ┌──────────┬─────────┐
- * │ iterator │ static  │
- * │ snapshot │ static  │
- * │ live     │ dynamic │
- * └──────────┴─────────┘
+ * ┌─────────────────┬─────────┐
+ * │ objects         │ dynamic │
+ * │ objectStream    │ static  │
+ * │ objectIterator  │ static  │
+ * │ objectsReadOnly │ static  │
+ * └─────────────────┴─────────┘
  * </pre>
  *
  * <p>This table details the behavior of setter helper methods in terms of effect on existing statements in the


### PR DESCRIPTION
Fix the `WrapperResource` Javadoc so it reflects the actual method names used in the class.

Highlights the shortcomings of using Unicode tables in `<pre>` with non-`@Link`ed method names. Other shortcoming is that they're not navigable.

But I don't want to move to `<table>` in doc comments because they feel clukky.