### PR TITLE
Remove redundancy in Maven configuration

### DIFF
--- a/test/base/pom.xml
+++ b/test/base/pom.xml
@@ -29,16 +29,4 @@
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/test/commons/pom.xml
+++ b/test/commons/pom.xml
@@ -40,23 +40,4 @@
       <artifactId>slf4j-simple</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <configuration>
-          <verbose>false</verbose>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/test/jena/pom.xml
+++ b/test/jena/pom.xml
@@ -51,13 +51,6 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -30,6 +30,13 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <configuration>
+          <verbose>false</verbose>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/test/rdf4j/pom.xml
+++ b/test/rdf4j/pom.xml
@@ -63,13 +63,6 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
There was some redundancy and lack of consistence in the test modules. This moves all of the maven configuration to the base of the test module where it will be inherited by subprojects.