### PR TITLE
Use non-deprecated license configuration structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,18 +455,22 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
-          <header>./build-tools/license/HEADER.txt</header>
           <mapping>
             <java>SLASHSTAR_STYLE</java>
           </mapping>
-          <excludes>
-            <exclude>**/src/main/resources/**</exclude>
-            <exclude>**/src/test/resources/**</exclude>
-          </excludes>
-          <includes>
-            <include>**/src/main/java/**</include>
-            <include>**/src/test/java/**</include>
-          </includes>
+          <licenseSets>
+            <licenseSet>
+              <header>./build-tools/license/HEADER.txt</header>
+              <excludes>
+                <exclude>**/src/main/resources/**</exclude>
+                <exclude>**/src/test/resources/**</exclude>
+              </excludes>
+              <includes>
+                <include>**/src/main/java/**</include>
+                <include>**/src/test/java/**</include>
+              </includes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
The license plugin currently uses a deprecated structure that will eventually be removed. This updates our configuration to use the current structure.