### PR TITLE
Use --release compiler argument for java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,7 @@
 
   <properties>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.release>8</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
This makes use of the more modern `--release` compiler argument in place of the older `-source` and `-target` arguments