### PR TITLE
Update jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,9 @@
     <jena.version>4.10.0</jena.version>
     <inrupt.commons.rdf4j.version>0.6.0</inrupt.commons.rdf4j.version>
 
+    <!-- transitive dependencies -->
+    <jackson.version>2.17.2</jackson.version>
+
     <!-- plugins -->
     <clean.plugin.version>3.4.0</clean.plugin.version>
     <checkstyle.plugin.version>3.4.0</checkstyle.plugin.version>
@@ -93,6 +96,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.eclipse.rdf4j</groupId>
         <artifactId>rdf4j-bom</artifactId>


### PR DESCRIPTION
RDF4J 4 and Jena 4 both bring in an older version of Jackson. This ensures that we're building and testing against a more modern version of that library