### PR TITLE
Consolidate dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      plugins:
+        patterns:
+          - "org.apache.maven.plugins:*"
+          - "com.mycila:license-maven-plugin"
+          - "org.jacoco:jacoco-maven-plugin"
+          - "org.sonarsource.scanner.maven:sonar-maven-plugin"
+          - "org.sonatype.plugins:nexus-staging-maven-plugin"
+          - "org.owasp:dependency-check-maven"
+          - "com.puppycrawl.tools:checkstyle"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,7 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>${source.plugin.version}</version>
           <executions>
@@ -262,6 +263,7 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${compiler.plugin.version}</version>
           <configuration>
@@ -272,6 +274,7 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${surefire.plugin.version}</version>
           <configuration>
@@ -282,6 +285,7 @@
           </configuration>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <!-- keep the surefire and failsafe plugin versions aligned -->
           <version>${surefire.plugin.version}</version>


### PR DESCRIPTION
This adjusts the dependabot configuration to group all plugin updates. This should reduce the noise from dependabot updates.