### PR TITLE
JCL-471: Upgrade maven central publication mechanism

### DIFF
--- a/.github/workflows/cd-config.yml
+++ b/.github/workflows/cd-config.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
           java-version: 17
           cache: 'maven'
-          server-id: 'ossrh'
+          server-id: 'central'
           server-username: MAVEN_REPO_USERNAME
           server-password: MAVEN_REPO_TOKEN
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <jar.plugin.version>3.4.2</jar.plugin.version>
     <javadoc.plugin.version>3.11.2</javadoc.plugin.version>
     <license.plugin.version>5.0.0</license.plugin.version>
-    <nexus.plugin.version>1.7.0</nexus.plugin.version>
     <owasp.plugin.version>12.1.1</owasp.plugin.version>
     <projectinfo.plugin.version>3.9.0</projectinfo.plugin.version>
     <pmd.plugin.version>3.26.0</pmd.plugin.version>
@@ -44,6 +43,7 @@
     <resources.plugin.version>3.3.1</resources.plugin.version>
     <site.plugin.version>3.21.0</site.plugin.version>
     <sonar.plugin.version>5.1.0.4751</sonar.plugin.version>
+    <sonatype.plugin.version>0.7.0</sonatype.plugin.version>
     <source.plugin.version>3.3.1</source.plugin.version>
     <surefire.plugin.version>3.5.3</surefire.plugin.version>
     <guava.version>33.4.8-jre</guava.version>
@@ -79,16 +79,6 @@
   </modules>
 
   <distributionManagement>
-    <snapshotRepository>
-      <name>Snapshot Repository</name>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <name>Staging Repository</name>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
     <site child.site.url.inherit.append.path="false">
       <id>${project.artifactId}</id>
       <url>${project.baseUri}</url>
@@ -449,15 +439,9 @@
           <version>${sonar.plugin.version}</version>
         </plugin>
         <plugin>
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus.plugin.version}</version>
-          <extensions>true</extensions>
-          <configuration>
-            <serverId>ossrh</serverId>
-            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-          </configuration>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>${sonatype.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.owasp</groupId>
@@ -582,6 +566,15 @@
           </suppressionFile>
           <nvdApiKey>${nvd.api.key}</nvdApiKey>
           <nvdDatafeedUrl>${nvd.api.datafeed}</nvdDatafeedUrl>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Maven central has migrated to a new infrastructure. This updates our configuration to use the new infrastructure.